### PR TITLE
Fix clinic email language

### DIFF
--- a/pet_mvp/notifications/tasks.py
+++ b/pet_mvp/notifications/tasks.py
@@ -226,7 +226,7 @@ def send_medical_record_email(exam, lang):
     )
 
     if clinic.default_language != lang:
-        context['lant'] = clinic.default_language
+        context['lang'] = clinic.default_language
 
     EmailService.send_template_email_async.delay(
         subject=_("Medical Examination Report for {} - {}").format(exam.pet.name,


### PR DESCRIPTION
## Summary
- fix `lang` context key in `send_medical_record_email`

## Testing
- `pytest -q tests/notifications/tasks/test_medical_record_email.py` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6840d98adc1c83248211cae05e30ab3d