### PR TITLE
Implement duplicate pet IntegrityError test

### DIFF
--- a/tests/pets/models/test_pet.py
+++ b/tests/pets/models/test_pet.py
@@ -125,9 +125,9 @@ class PetModelTests(TestCase):
             passport_number="AB12345678"  # Same passport number
         )
 
-        # Since we're using an in-memory database for tests, we'll skip this test
-        # In a real database, this would raise an IntegrityError
-        pass
+        from django.db.utils import IntegrityError
+        with self.assertRaises(IntegrityError):
+            duplicate_pet.save()
 
     def test_photo_handling(self):
         """Test that the save method handles photo renaming correctly."""


### PR DESCRIPTION
## Summary
- assert IntegrityError is raised when saving a pet with a duplicate passport number

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840dfb5a48c83249f6fae6a96eaa614