### PR TITLE
Fix default size docstring

### DIFF
--- a/pet_mvp/common/utils.py
+++ b/pet_mvp/common/utils.py
@@ -40,7 +40,7 @@ def resize_image(image_path, output_path, size=(300, 300)):
 
     :param image_path: Path to the input image.
     :param output_path: Path to save the resized image.
-    :param size: Desired size (width, height) tuple. Default is (150, 150).
+    :param size: Desired size (width, height) tuple. Default is (300, 300).
     """
     try:
         with Image.open(image_path) as img:


### PR DESCRIPTION
## Summary
- correct default size description in `resize_image`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840dfb515e88324a8038e13277ff1bb