### PR TITLE
Fix sitemap docs and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,12 @@ docker-compose up --build
 The site will be available at ``http://localhost:8000`` and Mailhog can be
 accessed at ``http://localhost:8025``. Stop the containers with
 ``docker-compose down`` when you are finished.
+
+## Configuring the Site domain
+
+If your generated ``sitemap.xml`` contains ``example.com`` URLs, update the
+default ``Site`` entry in the Django admin. Navigate to ``/admin/sites/site/1``
+and set the ``domain`` and ``name`` fields to match your real deployment
+domain. This ensures the sitemap links use the correct hostname and avoids
+errors like "This url is not allowed for a Sitemap at this location" during
+sitemap validation.

--- a/pet_mvp/common/sitemaps.py
+++ b/pet_mvp/common/sitemaps.py
@@ -6,7 +6,16 @@ class StaticViewSitemap(Sitemap):
     changefreq = 'monthly'
 
     def items(self):
-        return ['index', 'about', 'login', 'register']
+        return [
+            'index',
+            'about',
+            'login',
+            'register',
+            'clinic-login',
+            'password-entry',
+            'clinic-register',
+            'forgot-password',
+        ]
 
     def location(self, item):
         return reverse(item)


### PR DESCRIPTION
## Summary
- remove stray mailhog binary from git history
- expand docs with instructions to set the Site domain

## Testing
- `CLIENT_ID=xyz CLIENT_SECRET=abc SECRET_KEY=abc python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6841c09bb98c8324b6a77c2c53217aa1