### PR TITLE
Fix accounts tests

### DIFF
--- a/pet_mvp/accounts/forms.py
+++ b/pet_mvp/accounts/forms.py
@@ -44,8 +44,8 @@ class BaseOwnerForm(forms.ModelForm):
         first_name = self.cleaned_data.get('first_name')
         last_name = self.cleaned_data.get('last_name')
 
-        if hasattr(user, 'owner_profile'):
-            profile = user.owner_profile
+        if hasattr(user, 'owner'):
+            profile = user.owner
         else:
             profile = Owner(user=user)
 

--- a/pet_mvp/accounts/models.py
+++ b/pet_mvp/accounts/models.py
@@ -99,6 +99,18 @@ class AppUser(AbstractBaseUser, PermissionsMixin):
     def __str__(self):
         return self.get_full_name()
 
+    @property
+    def first_name(self):
+        if hasattr(self, 'owner'):
+            return self.owner.first_name
+        return ''
+
+    @property
+    def last_name(self):
+        if hasattr(self, 'owner'):
+            return self.owner.last_name
+        return ''
+
 
 class Owner(models.Model):
     user = models.OneToOneField(

--- a/pet_mvp/accounts/views.py
+++ b/pet_mvp/accounts/views.py
@@ -91,11 +91,13 @@ class BaseUserRegisterView(views.CreateView):
         except UserModel.DoesNotExist:
             return False  # User does not exist or is not inactive
 
-        password = form.cleaned_data.get('password1')
+        password = form.data.get('password1')
         user.set_password(password)
-        user.owner.first_name = form.cleaned_data['first_name']
-        user.owner.last_name = form.cleaned_data['last_name']
+        owner = user.owner
+        owner.first_name = form.data.get('first_name')
+        owner.last_name = form.data.get('last_name')
         user.is_active = True
+        owner.save()
         user.save()
 
         login(self.request, user, backend='django.contrib.auth.backends.ModelBackend')

--- a/pet_mvp/notifications/tasks.py
+++ b/pet_mvp/notifications/tasks.py
@@ -16,12 +16,12 @@ UserModel = get_user_model()
 def send_clinic_owner_access_request_email(user_owner, user_clinic, pet, url, lang):
 
     context = {
-        "owner_name": user_owner.owner.get_full_name(),
+        "owner_name": user_owner.get_full_name(),
         "clinic_name": user_clinic.clinic.clinic_name,
-        "clinic_email": user_clinic.clinic.email,
-        "clinic_phone": user_clinic.clinic.phone_number,
-        "clinic_city": user_clinic.clinic.city,
-        "clinic_country": user_clinic.clinic.country,
+        "clinic_email": user_clinic.email,
+        "clinic_phone": user_clinic.phone_number,
+        "clinic_city": user_clinic.city,
+        "clinic_country": user_clinic.country,
         "pet_name": pet.name,
         "approval_url": url,
         "lang": lang,

--- a/tests/accounts/test_google_login.py
+++ b/tests/accounts/test_google_login.py
@@ -1,10 +1,28 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.sites.models import Site
+from allauth.socialaccount.models import SocialApp
+from django.test.utils import override_settings
 
 class GoogleLoginTest(TestCase):
     def setUp(self):
         Site.objects.update_or_create(id=1, defaults={'domain': 'localhost:8000', 'name': 'localhost'})
+        self.override = override_settings(
+            SOCIALACCOUNT_PROVIDERS={
+                'google': {
+                    'APP': {
+                        'client_id': 'dummy',
+                        'secret': 'dummy',
+                        'key': ''
+                    }
+                }
+            }
+        )
+        self.override.enable()
+
+    def tearDown(self):
+        self.override.disable()
+        super().tearDown()
 
     def test_index_page_has_google_button(self):
         response = self.client.get(reverse('index'))


### PR DESCRIPTION
## Summary
- enable allauth override in google login tests
- fix owner profile detection and registration restore
- expose owner fields on AppUser model
- correct clinic email context

## Testing
- `python manage.py test tests.accounts -v 2`

------
https://chatgpt.com/codex/tasks/task_e_684241e092e88324a0fa5f26d2151a46