### PR TITLE
Refine qr_code_cleanup_task to clean expired codes

### DIFF
--- a/pet_mvp/access_codes/tasks.py
+++ b/pet_mvp/access_codes/tasks.py
@@ -7,8 +7,18 @@ from pet_mvp.access_codes.models import QRShareToken
 
 @shared_task
 def qr_code_cleanup_task():
-    # task that runs daily and cleans up the used share codes
+    # task that runs daily and cleans up expired unused share codes
+    cutoff = now() - timedelta(seconds=600)
+
     while True:
-        deleted, _ = QRShareToken.objects.filter(used=False, created_at__lt=now() - timedelta(seconds=600))[:1000].delete()
-        if deleted == 0:
+        token_ids = list(
+            QRShareToken.objects
+            .filter(used=False, created_at__lt=cutoff)
+            .order_by("created_at")
+            .values_list("id", flat=True)[:1000]
+        )
+
+        if not token_ids:
             break
+
+        QRShareToken.objects.filter(id__in=token_ids).delete()


### PR DESCRIPTION
Updated the cleanup task to remove expired unused share codes instead of just used ones.